### PR TITLE
Created by Atomist project editor atomist-project-templates.spring-boot-common-editors.AddFeignClientWithCircuitBreaker

### DIFF
--- a/.provenance.txt
+++ b/.provenance.txt
@@ -114,3 +114,22 @@ sha: 71d6c5f
 # parameter values
 base_docker_repository: russmile
 
+####
+
+# editor info
+name: atomist-project-templates.spring-boot-common-editors.AddFeignClientWithCircuitBreaker
+group: atomist-project-templates
+artifact: spring-boot-common-editors
+version: 1.8.1
+
+# backing git repo
+repo: atomist-project-templates/spring-boot-common-editors.git
+branch: master
+sha: 71d6c5f
+
+# parameter values
+consumed_endpoint_address: <https://sylvainslaptop>
+feign_interface: Hollywood
+invoking_relative_endpoint_url: /movies
+endpoint_invoking_method: getMyMovie
+

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,15 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+		<dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-feign</artifactId>
+        </dependency>
+    	<dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-hystrix</artifactId>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>
@@ -117,4 +125,14 @@
         </plugins>
 	</build>
 
+	<dependencyManagement>
+        <dependencies>	<dependency>
+              <groupId>org.springframework.cloud</groupId>
+              <artifactId>spring-cloud-dependencies</artifactId>
+              <version>Camden.RELEASE</version>
+              <type>pom</type>
+              <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/src/main/java/com/myorg/BigShotsApplication.java
+++ b/src/main/java/com/myorg/BigShotsApplication.java
@@ -2,8 +2,12 @@ package com.myorg;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.feign.EnableFeignClients;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableCircuitBreaker
 public class BigShotsApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/myorg/Hollywood.java
+++ b/src/main/java/com/myorg/Hollywood.java
@@ -1,0 +1,19 @@
+package com.myorg;
+
+import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@FeignClient(name = "<https://sylvainslaptop>", fallback = HollywoodFallback.class)
+interface Hollywood {
+    @RequestMapping(value = "/movies", method = GET)
+    String getMyMovie();
+}
+
+class HollywoodFallback implements Hollywood {
+    @Override
+    public String getMyMovie() {
+        return null;
+    }
+}


### PR DESCRIPTION
Adds a simple Feign Client interface in the default Spring Boot Application Class location including a default service-consuming method and Circuit Breaker fallback method